### PR TITLE
Fix conversion of ra in js

### DIFF
--- a/converter/generator.py
+++ b/converter/generator.py
@@ -27,6 +27,10 @@ def re_sub(value, find, replace):
 def hex_encode(value):
     return value.encode('utf8').decode('unicode_escape')
 
+def js_re_sub(value):
+    # js regex doesn't support lookbehinds
+    return re.sub("\?<=" , "", value)
+
 def main():
     cwd_dir = pathlib.Path(__file__).parent
     rules_files = list(cwd_dir.glob('*.rules'))
@@ -64,6 +68,7 @@ def main():
                 template = Template(templateFile.read())
                 template.environment.filters['re_sub'] = re_sub
                 template.environment.filters['hex_encode'] = hex_encode
+                template.environment.filters['js_re_sub'] = js_re_sub
                 outputFile.write(template.render(**context))
 
 main()

--- a/converter/javascript/converter.js.template
+++ b/converter/javascript/converter.js.template
@@ -21,7 +21,7 @@
 function uni512zg1(input_text) {
     var output_text = input_text;
     {% for rule in uni512zg1_rules -%}
-    output_text = output_text.replace(/{{rule.0|replace("(?","(\?")}}/gm, "{{rule.1}}");
+    output_text = output_text.replace(/{{rule.0|js_re_sub}}/gm, "{{rule.1}}");
     {# // debugging -#}
     {# console.log("{{rule}}" -#}
     {% endfor -%}
@@ -31,7 +31,7 @@ function uni512zg1(input_text) {
 function zg12uni51(input_text) {
     var output_text = input_text;
     {% for rule in zg12uni51_rules -%}
-    output_text = output_text.replace(/{{rule.0|replace("(?", "(\?")}}/gm, "{{rule.1}}");
+    output_text = output_text.replace(/{{rule.0|js_re_sub}}/gm, "{{rule.1}}");
     {# // debugging -#}
     {# console.log("{{rule}}" -#}
     {% endfor -%}


### PR DESCRIPTION
It is being caused by this [rule](https://github.com/trhura/paytan/blob/master/converter/uni512zg1.rules#L37). Well, not the rule itself, but the question mark in second matching group is being escaped in the generated `converter.js`. Since, javascript regex doesn't support lookbehinds, completely escaping `?` [here](https://github.com/trhura/paytan/blob/master/converter/javascript/converter.js.template#L24) would cause incorrect matchings for non-capturing groups `?:` and lookaheads patterns `?=` and optional groups `()?`.

Anyway, I notice that without positive lookbehinds, the logic of the regex doesn't change ([parabaik](https://github.com/ngwestar/parabaik/blob/master/scripts/uni512zg1.js) doesn't use any lookbehinds). So, my fix gets rid of positive lookbehinds. `?<=`. So, there is no need for completely escaping question mark character anymore.

![screen shot 2015-02-26 at 07 25 03](https://cloud.githubusercontent.com/assets/264626/6383034/b71d408c-bd88-11e4-885e-e9bc1563e0b3.png)
